### PR TITLE
Use 'as' for typecasting

### DIFF
--- a/v3/TexParser/ts/map_handler.ts
+++ b/v3/TexParser/ts/map_handler.ts
@@ -81,7 +81,7 @@ export default class MapHandler {
    * @return {T} A boolean, Character, or Macro.
    */
   public lookup<T>(symbol: string): T {
-    let map = <AbstractSymbolMap<T>>(this.applicable(symbol));
+    let map = this.applicable(symbol) as AbstractSymbolMap<T>;
     return map ? map.lookup(symbol) : null;
   }
   


### PR DESCRIPTION
I personally think `as` is more readable, especially since `<>` already has another meaning in the very same expression. See the bottom of https://www.typescriptlang.org/docs/handbook/basic-types.html. 