### PR TITLE
Pin Typescript to 2.1.x

### DIFF
--- a/v3/TexParser/package.json
+++ b/v3/TexParser/package.json
@@ -4,7 +4,7 @@
   "description": "Attempt to parse ",
   "main": "index.js",
   "devDependencies": {
-    "typescript": ">=1.8.10",
+    "typescript": "~2.1.0",
     "typescript-tools": "*",
     "tss": "*",
     "tslint": ">=3.15.0",

--- a/v3/TexParser/package.json
+++ b/v3/TexParser/package.json
@@ -4,7 +4,7 @@
   "description": "Attempt to parse ",
   "main": "index.js",
   "devDependencies": {
-    "typescript": "~2.1.0",
+    "typescript": "2.1.*",
     "typescript-tools": "*",
     "tss": "*",
     "tslint": ">=3.15.0",


### PR DESCRIPTION
Typescript minor versions may not be compatible with other minor versions, so it's better to pin the minor version the code is compatible with.